### PR TITLE
fix blog open

### DIFF
--- a/plugin/blog.vim
+++ b/plugin/blog.vim
@@ -998,9 +998,9 @@ def blog_guess_open(what):
     blog_index = -1
     if type(what) is str:
 
-        for i, p in enumerate(vim.eval("VIMPRESS")):
-            if what.startswith(p["blog_url"]):
-                blog_index = i
+	    #for i, p in enumerate(vim.eval("VIMPRESS")):
+            #    if what.startswith(p["blog_url"]):
+            #        blog_index = i
 
         # User input a url contained in the profiles
         if blog_index != -1:


### PR DESCRIPTION
MrPeterLeeのブランチでの、BlogOpenで存在しないVIMPRESS変数を参照して発生するエラーの修正を反映します。
https://github.com/MrPeterLee/VimWordpress/commit/32addb8d8d5dabe3e4ffa9f1edb3b606c4953e50